### PR TITLE
Fix: iPhone status bar color and iphone notch spacing issues

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,9 +1,13 @@
 import { Stack } from "expo-router";
+import { StatusBar } from "expo-status-bar";
 
 export default function RootLayout() {
   return (
-    <Stack screenOptions={{ headerShown: false }}>
-      <Stack.Screen name="(tabs)" />
-    </Stack>
+    <>
+      <StatusBar style="light" />
+      <Stack screenOptions={{ headerShown: false }}>
+        <Stack.Screen name="(tabs)" />
+      </Stack>
+    </>
   );
 }

--- a/components/AppHeader.tsx
+++ b/components/AppHeader.tsx
@@ -103,7 +103,7 @@ const styles = StyleSheet.create({
     padding: 4,
     overflow: "hidden",
     backgroundColor: "rgba(255,255,255,0.15)",
-    transform: Platform.OS === "web" ? [] : [{ translateY: -25 }],
+    transform: Platform.OS === "web" ? [] : [{ translateY: -15 }],
     marginTop: Platform.OS === "web" ? -20 : 0,
   },
 


### PR DESCRIPTION
-Made the status bar white for better readability on iPhone
-Added spacing so the SGW/Loyola toggle isn’t covered by the IPhone notch

Closes #334 
Closes #333