### PR TITLE
Building information displays for Android (fix)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -550,7 +550,7 @@ export default function MapScreen() {
     userLng,
   ]);
 
-  const webViewSource = useMemo(() => ({ html: mapHTML, baseUrl: 'https://localhost' }), [mapHTML]);
+  const webViewSource = useMemo(() => ({ html: mapHTML }), [mapHTML]);
 
   const shouldUseWebFallback = Platform.OS === "web" || !MapViewComponent;
 


### PR DESCRIPTION
Building information tabs were not showing on Androids consistently. Changed the code so that it uses URL redirects instead of WebView messaging.

Tested on Android and iOS devices. 